### PR TITLE
Don't use global grunt

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,6 @@
 
 ```bash
 npm install
-grunt build
-```
-
-Don't have grunt installed?
-```bash
-npm install -g grunt-cli
 ```
 
 We are using [js-cookie](https://github.com/js-cookie/js-cookie) for storing and loading cookies.

--- a/main.go
+++ b/main.go
@@ -19,12 +19,6 @@ func BuildSite() (string, error) {
 		os.Chdir(working) // change dir back to working directory
 		return path, errors.New("Jimmify Web: could not run npm install")
 	}
-	grunt := exec.Command("grunt", "build")
-	err = grunt.Run()
-	if err != nil {
-		os.Chdir(working) // change dir back to working directory
-		return path, errors.New("Jimmify Web: could not run grunt build")
-	}
 	os.Chdir(working) // change dir back to working directory
 	return path, nil
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "personalized jimmy search",
   "main": "index.js",
   "scripts": {
+    "start": "grunt watch",
+    "prepublish": "npm run build",
+    "build": "grunt build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
- Remove the need to install grunt globally
- Automatically build files after `npm install`